### PR TITLE
ACPAcquisition v2.0.2 release

### DIFF
--- a/ACPAcquisition.podspec
+++ b/ACPAcquisition.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "ACPAcquisition"
-  s.version      = "2.0.1"
+  s.version      = "2.0.2"
   s.summary      = "Acquisition library for Adobe Experience Platform SDK. Written and maintained by Adobe."
   s.description  = <<-DESC
                    The Acquisition library provides APIs that allow use of the Acquisition product in the Adobe Experience Platform SDK.

--- a/include/ACPAcquisition.h
+++ b/include/ACPAcquisition.h
@@ -4,7 +4,7 @@
 //
 //  Copyright 1996-2019. Adobe. All Rights Reserved
 //
-//  Acquisition Version: 2.0.1
+//  Acquisition Version: 2.0.2
 
 #import <Foundation/Foundation.h>
 


### PR DESCRIPTION
Fix for duplicate Analytics hits when ACPCore::CollectLaunchInfo is called. ACPAcquisition no longer dispatches Analytics request event when receiving CollectLaunchInfo event.
