### PR TITLE
ACPAcquisition v2.0.2 release (manual install)

### DIFF
--- a/iOS/ACPAcquisition/include/ACPAcquisition.h
+++ b/iOS/ACPAcquisition/include/ACPAcquisition.h
@@ -4,7 +4,7 @@
 //
 //  Copyright 1996-2019. Adobe. All Rights Reserved
 //
-//  Acquisition Version: 2.0.1
+//  Acquisition Version: 2.0.2
 
 #import <Foundation/Foundation.h>
 


### PR DESCRIPTION
ACPAcquisition v2.0.2 release libs for manual install.

- Fix for duplicate Analytics hits when ACPCore::CollectLaunchInfo is called. ACPAcquisition no longer dispatches Analytics request event when receiving CollectLaunchInfo event.

