### PR TITLE
PR for Griffon 1.1.1 release

### DIFF
--- a/ACPGriffon.podspec
+++ b/ACPGriffon.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "ACPGriffon"
-  s.version      = "1.1.0"
+  s.version      = "1.1.1"
   s.summary      = "Project Griffon SDK for Adobe Experience Cloud. Written and maintained by Adobe."
   s.description  = <<-DESC
                    The Project Griffon SDK provides APIs that allow use of the Project Griffon product in conjunction with the Adobe Experience Cloud solutions.

--- a/include/ACPGriffon.h
+++ b/include/ACPGriffon.h
@@ -4,7 +4,7 @@
 //
 //  Copyright 1996-2020. Adobe. All Rights Reserved
 //
-//  ACPGriffon Version: 1.1.0
+//  ACPGriffon Version: 1.1.1
 
 #import <Foundation/Foundation.h>
 

--- a/include/ACPGriffonEvent.h
+++ b/include/ACPGriffonEvent.h
@@ -4,7 +4,7 @@
 //
 //  Copyright 1996-2020. Adobe. All Rights Reserved
 //
-//  ACPGriffon Version: 1.1.0
+//  ACPGriffon Version: 1.1.1
 
 #import <Foundation/Foundation.h>
 


### PR DESCRIPTION
Release Notes:

- Griffon extension is optimized to unregister itself, when it does not obtain session's deeplink URL within 5 seconds of app launch.
- Fixed a bug where user is not able to disconnect when griffon attempts to reconnect with expired socket URL.
- Support for prod, stage, qa and dev environment.
- Griffon socket connection now authenticates against organization Id.
- Griffon SDK attempts to seemlessly reconnect to its session on network interruption.
- Fixed an issue where "Connect" button doesnot appear in the pinpad screen on iOS version 10 and below
- Fixed a crash that happens when screenshots fails to upload to blob service. 